### PR TITLE
Adapt window size dynamically to different title bar heights

### DIFF
--- a/FriendlySetPlugin.cs
+++ b/FriendlySetPlugin.cs
@@ -53,21 +53,7 @@ namespace FriendlySetTime
                     ShowMinimizeButton = false,
                 });
 
-                var themeName = PlayniteApi.ApplicationSettings.DesktopTheme;
-
-                var comparisonResult = themeName == "Stardust 2.0_1fb333b2-255b-43dd-aec1-8e2f2d5ea002"
-                    || themeName == "Mythic_e231056c-4fa7-49d8-ad2b-0a6f1c589eb8";
-
-                if (comparisonResult)
-                {
-                    window.Height = 195;
-                }
-                else
-                {
-                    window.Height = 170;
-                }
-
-                window.Width = 520;
+                window.SizeToContent = SizeToContent.WidthAndHeight;
                 window.Title = "Set Time";
                 window.Content = view;
 

--- a/FriendlySetPlugin.cs
+++ b/FriendlySetPlugin.cs
@@ -55,7 +55,10 @@ namespace FriendlySetTime
 
                 var themeName = PlayniteApi.ApplicationSettings.DesktopTheme;
 
-                if (themeName == "Stardust 2.0_1fb333b2-255b-43dd-aec1-8e2f2d5ea002")
+                var comparisonResult = themeName == "Stardust 2.0_1fb333b2-255b-43dd-aec1-8e2f2d5ea002"
+                    || themeName == "Mythic_e231056c-4fa7-49d8-ad2b-0a6f1c589eb8";
+
+                if (comparisonResult)
                 {
                     window.Height = 195;
                 }

--- a/FriendlySetPlugin.cs
+++ b/FriendlySetPlugin.cs
@@ -53,7 +53,17 @@ namespace FriendlySetTime
                     ShowMinimizeButton = false,
                 });
 
-                window.Height = 170;
+                var themeName = PlayniteApi.ApplicationSettings.DesktopTheme;
+
+                if (themeName == "Stardust 2.0_1fb333b2-255b-43dd-aec1-8e2f2d5ea002")
+                {
+                    window.Height = 195;
+                }
+                else
+                {
+                    window.Height = 170;
+                }
+
                 window.Width = 520;
                 window.Title = "Set Time";
                 window.Content = view;


### PR DESCRIPTION
Some themes have a bigger title bar than the default theme and the current window height is too small for them which leads to part of the window being hidden.

Screenshot:
![grafik](https://user-images.githubusercontent.com/24878047/193469368-8aaae839-29bd-45a8-824a-b29c855a37c1.png)


Instead of adding an overwrite for these themes I changed the fixed Height and Width to a dynamic one that resizes when the window is opened. The resize is done only once and should fix this issue for all themes.